### PR TITLE
Hotfix/anchor link css class

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -39,6 +39,10 @@ class Schema
     private function get_link_styled($tagName)
     {
         return function ($node) use ($tagName) {
+            if (strlen($node['attrs']['anchor']) == 0 || $node['attrs']['anchor'] == null) {
+                unset($node['attrs']['anchor']);
+            }
+
             if ($node['attrs']['anchor']) {
                 $attrs = $node['attrs'];
                 $attrs['href'] = $attrs['href'] . "#" . $attrs['anchor'];

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -420,4 +420,72 @@ class ResolverTest extends TestCase {
 
         $this->assertEquals($resolver->render((object) $data), $expected);
     }
+
+    public function testRenderLinkTagWithoutAnchor ()
+    {
+        $resolver = new Resolver();
+
+        $data = [
+            "type" => "doc",
+            "content" => [
+                [
+                    "text" => "link text",
+                    "type" => "text",
+                    "marks" => [
+                        [
+                            "type" => "link",
+                            "attrs" => [
+                                "href" => "/link",
+                                "target" => "_blank",
+                                "title" => "Any title",
+                                "anchor" => ""
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $expected = '<a href="/link" target="_blank" title="Any title">link text</a>';
+
+        $this->assertEquals($resolver->render((object) $data), $expected);
+    }
+
+
+
+    public function testRenderLinkTagWithoutAnchorButWithCssClass ()
+    {
+        $resolver = new Resolver();
+
+        $data = [
+            "type" => "doc",
+            "content" => [
+                [
+                    "text" => "link text",
+                    "type" => "text",
+                    "marks" => [
+                        [
+                            "type" => "link",
+                            "attrs" => [
+                                "href" => "/link",
+                                "target" => "_blank",
+                                "title" => "Any title",
+                                "anchor" => ""
+                            ]
+                        ],
+                        [
+                            "type" => "styled",
+                                "attrs" => [
+                                    "class" => "css__class"
+                                ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $expected = '<a href="/link" target="_blank" title="Any title"><span class="css__class">link text</span></a>';
+
+        $this->assertEquals($resolver->render((object) $data), $expected);
+    }
 }


### PR DESCRIPTION
In this Pull request, I am solving the bug that occurs when we add a style class to the links and it renders an anchor without the same.