### PR TITLE
Hotfix/styled function

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -15,8 +15,8 @@ class Schema
             'strong' => $this->get_tag('tag', 'strong'),
             'code' => $this->get_tag('tag', 'code'),
             'italic' => $this->get_tag('tag', 'i'),
-            'link' => $this->get_link_styled('a'),
-            'styled' => $this->get_link_styled('span'),
+            'link' => $this->get_link('a'),
+            'styled' => $this->get_tag_styled('span'),
         ];
     }
 
@@ -36,7 +36,7 @@ class Schema
         ];
     }
 
-    private function get_link_styled($tagName)
+    private function get_link($tagName)
     {
         return function ($node) use ($tagName) {
             if (strlen($node['attrs']['anchor']) == 0 || $node['attrs']['anchor'] == null) {
@@ -77,6 +77,20 @@ class Schema
                 $tag => $tagName
             ];
         };
+    }
+
+    private function get_tag_styled($tagName)
+    {
+       return function ($node) use ($tagName) {
+            return [
+                "tag" => [
+                    [
+                        "tag" => $tagName,
+                        "attrs" => $node['attrs']
+                    ]
+                ]
+            ];
+       };
     }
 
     private function get_image()

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -488,4 +488,109 @@ class ResolverTest extends TestCase {
 
         $this->assertEquals($resolver->render((object) $data), $expected);
     }
+
+    public function testRenderParagraphWithClassAttribute ()
+    {
+        $resolver = new Resolver();
+
+        $data = [
+            "type" => "doc",
+            "content" => [
+                [
+                "type" => "paragraph",
+                "content" => [
+                  [
+                    "text" => "Storyblok visual editor is ",
+                    "type" => "text"
+                  ],
+                  [
+                    "text" => "awesome!",
+                    "type" => "text",
+                    "marks" => [
+                      [
+                        "type" => "styled",
+                        "attrs" => [
+                          "class" => "highlight"
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+        ];
+
+        $expected = '<p>Storyblok visual editor is <span class="highlight">awesome!</span></p>';
+
+        $this->assertEquals($resolver->render((object) $data), $expected);
+    }
+
+
+    public function testRenderParagraphWithThreeClassAttribute ()
+    {
+        $resolver = new Resolver();
+
+        $data = [
+            "type" => "doc",
+            "content" => [
+                [
+                    "type" => "paragraph",
+                    "content" => [
+                        [
+                            "text" => "This is a ",
+                            "type" => "text"
+                        ],
+                        [
+                            "text" => "awesome",
+                            "type" => "text",
+                            "marks" => [
+                                [
+                                    "type" => "styled",
+                                    "attrs" => [
+                                        "class" => "test"
+                                    ]
+                                ]
+                            ]
+                        ],
+                        [
+                            "text" => " text and this ",
+                            "type" => "text"
+                        ],
+                        [
+                            "text" => "renderer",
+                            "type" => "text",
+                            "marks" => [
+                                [
+                                    "type" => "styled",
+                                    "attrs" => [
+                                    "class" => "red"
+                                        ]
+                                ]
+                            ]
+                        ],
+                        [
+                            "text" => " is built with ",
+                            "type" => "text"
+                        ],
+                        [
+                            "text" => "php.",
+                            "type" => "text",
+                            "marks" => [
+                                [
+                                    "type" => "styled",
+                                    "attrs" => [
+                                        "class" => "test__red"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $expected = '<p>This is a <span class="test">awesome</span> text and this <span class="red">renderer</span> is built with <span class="test__red">php.</span></p>';
+
+        $this->assertEquals($resolver->render((object) $data), $expected);
+    }
 }


### PR DESCRIPTION
This PR solves the problem reported in this [issue](https://github.com/storyblok/storyblok-php-richtext-renderer/issues/3).

In this PR I divided the function that generated the links `get_link_styled('span')`, because it also generated style tags, with the division, we now have a specific function for generating links `get_link('a')` and one for generating style tags `get_tag_styled('span')`, and also added more test cases.