### PR TITLE
Remove invalid linktype attribute

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -41,6 +41,7 @@ class Schema
         return static function ($node) use ($tagName) {
             $attrs = $node['attrs'];
             $linkType = Utils::get($attrs, 'linktype', 'url');
+            unset($attrs['linktype']);
 
             if (array_key_exists('anchor', $attrs)) {
                 $anchor = $attrs['anchor'];
@@ -57,7 +58,7 @@ class Schema
             }
 
             if ($linkType === 'story') {
-                unset($attrs['story'], $attrs['linktype'], $attrs['uuid']);
+                unset($attrs['story'], $attrs['uuid']);
             }
 
             return [

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -91,6 +91,7 @@ class ResolverTest extends TestCase
                             "attrs" => [
                                 "href" => "/link",
                                 "target" => "_blank",
+                                "linktype" => "link",
                                 "title" => "Any title"
                             ]
                         ]
@@ -129,7 +130,7 @@ class ResolverTest extends TestCase
             ]
         ];
 
-        $expected = '<a href="mailto:email@client.com" target="_blank" linktype="email" title="Any title">an email link</a>';
+        $expected = '<a href="mailto:email@client.com" target="_blank" title="Any title">an email link</a>';
 
         $this->assertEquals($expected, $resolver->render((object)$data));
     }


### PR DESCRIPTION
The previous logic was: if the type of link is not a story (e.g., normal link or email etc), then the "linktype" attribute is "leaked" out into the generated html - which is wrong since it is not a valid html attribute.

As you can see below, the email link test was broken (I think) since it was actually expecting that attribute.

The fix is easy, and we have 2 tests ensuring it works.