### PR TITLE
Fix various problems with custom link attributes

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -61,6 +61,11 @@ class Schema
                 unset($attrs['story'], $attrs['uuid']);
             }
 
+            if (isset($attrs['custom']) && is_array($attrs['custom'])) {
+                $attrs = array_merge($attrs, $attrs['custom']);
+            }
+            unset($attrs['custom']);
+
             return [
                 "tag" => [
                     [

--- a/src/Utils/Render.php
+++ b/src/Utils/Render.php
@@ -42,11 +42,6 @@ class Render
             $result = "<{$tag['tag']}";
 
             if (array_key_exists('attrs', $tag)) {
-                if (isset($tag['attrs']['custom']) && is_array($tag['attrs']['custom'])) {
-                    $tag['attrs'] = array_merge($tag['attrs'], $tag['attrs']['custom']);
-                    unset($tag['attrs']['custom']);
-                }
-
                 foreach ($tag['attrs'] as $key => $value) {
                     if (!is_null($value)) {
                         $result .= " $key=\"$value\"";

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -137,6 +137,36 @@ class ResolverTest extends TestCase
         $this->assertEquals($resolver->render((object) $data), $expected);
     }
 
+    public function testRenderLinkTagWithEmptyCustomAttributesArrayShouldNotCauseErrors()
+    {
+        $resolver = new Resolver();
+
+        $data = [
+            "type" => "doc",
+            "content" => [
+                [
+                    "text" => "link text",
+                    "type" => "text",
+                    "marks" => [
+                        [
+                            "type" => "link",
+                            "attrs" => [
+                                "href" => "/link",
+                                "target" => "_blank",
+                                "title" => "Any title",
+                                "custom" => []
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $expected = '<a href="/link" target="_blank" title="Any title">link text</a>';
+
+        $this->assertEquals($resolver->render((object) $data), $expected);
+    }
+
     public function testRenderLinkTagWithEmail()
     {
         $resolver = new Resolver();


### PR DESCRIPTION
- moved the custom attributes check from generic renderer to link renderer (in case some other element might also have a "custom" attribute entry with a different meaning)
- fix bug where empty custom attributes array (or non-array) would still cause errors because `isset($emptyArray)` is false and `unset()` would not be called
- add test for this latter case (before the fix the test was failing, so we know the hypothesis was correct and the change fixed it)