### PR TITLE
task(int-998): Add escape html function to links attributes

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -68,7 +68,7 @@ class Resolver
                 $html[] = $this->renderNode($content);
             }
         } elseif (\array_key_exists('text', $item)) {
-            $html[] = $this->renderer->escapeHTML($item['text']);
+            $html[] = Utils::escapeHTML($item['text']);
         } elseif ($node && \array_key_exists('single_tag', $node)) {
             $html[] = $this->renderer->renderTag($node['single_tag'], ' /');
         } elseif ($node && \array_key_exists('html', $node)) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -3,7 +3,6 @@
 namespace Storyblok\RichtextRender;
 
 use Storyblok\RichtextRender\Utils\Utils;
-use Storyblok\RichtextRender\Utils\Render;
 
 class Schema
 {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -3,6 +3,7 @@
 namespace Storyblok\RichtextRender;
 
 use Storyblok\RichtextRender\Utils\Utils;
+use Storyblok\RichtextRender\Utils\Render;
 
 class Schema
 {
@@ -48,6 +49,8 @@ class Schema
             $attrs = $node['attrs'];
             $linkType = Utils::get($attrs, 'linktype', 'url');
             unset($attrs['linktype']);
+
+            $attrs['href'] = Utils::escapeHTML($attrs['href']);
 
             if (\array_key_exists('anchor', $attrs)) {
                 $anchor = $attrs['anchor'];

--- a/src/Utils/Render.php
+++ b/src/Utils/Render.php
@@ -4,11 +4,6 @@ namespace Storyblok\RichtextRender\Utils;
 
 class Render
 {
-    public function escapeHTMl($html)
-    {
-        return htmlspecialchars($html, ENT_QUOTES);
-    }
-
     public function renderClosingTag($tags)
     {
         if (\is_string($tags)) {

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -26,4 +26,9 @@ class Utils
     {
         return \array_key_exists($key, $obj) ? $obj[$key] : $default;
     }
+
+    public static function escapeHTMl($html)
+    {
+        return htmlspecialchars($html, ENT_QUOTES);
+    }
 }

--- a/tests/Fixtures/ResolverTestData.php
+++ b/tests/Fixtures/ResolverTestData.php
@@ -4,163 +4,163 @@ namespace Storyblok\RichtextRender\Fixtures;
 
 class ResolverTestData
 {
-  public static function spanWithClassAttribute()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'text' => 'red text',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'styled',
-                        'attrs' => [
-                            'class' => 'red',
+    public static function spanWithClassAttribute()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'red text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'styled',
+                            'attrs' => [
+                                'class' => 'red',
+                            ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function linkTag()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'text' => 'link text',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'link',
-                        'attrs' => [
-                            'href' => '/link',
-                            'target' => '_blank',
-                            'linktype' => 'link',
-                            'title' => 'Any title',
+    public static function linkTag()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'link text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => '/link',
+                                'target' => '_blank',
+                                'linktype' => 'link',
+                                'title' => 'Any title',
+                            ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function linkTagWithEmptyCustomAttributes()
-  {
-    return [
-		'type' => 'doc',
-		'content' => [
-			[
-				'text' => 'link text',
-				'type' => 'text',
-				'marks' => [
-					[
-						'type' => 'link',
-						'attrs' => [
-							'href' => '/link',
-							'target' => '_blank',
-							'title' => 'Any title',
-							'custom' => [],
-						],
-					],
-				],
-			],
-		],
-	];
-  }
+    public static function linkTagWithEmptyCustomAttributes()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'link text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => '/link',
+                                'target' => '_blank',
+                                'title' => 'Any title',
+                                'custom' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
-  public static function linkTagWithEmail()
-  {
-    return [
-		'type' => 'doc',
-		'content' => [
-			[
-				'text' => 'an email link',
-				'type' => 'text',
-				'marks' => [
-					[
-						'type' => 'link',
-						'attrs' => [
-							'href' => 'email@client.com',
-							'target' => '_blank',
-							'linktype' => 'email',
-							'title' => 'Any title',
-						],
-					],
-				],
-			],
-		],
-	];
-  }
+    public static function linkTagWithEmail()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'an email link',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => 'email@client.com',
+                                'target' => '_blank',
+                                'linktype' => 'email',
+                                'title' => 'Any title',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
-  public static function tagWithNullAttribute()
-  {
-    return [
-		'type' => 'doc',
-		'content' => [
-			[
-				'text' => 'link text',
-				'type' => 'text',
-				'marks' => [
-					[
-						'type' => 'link',
-						'attrs' => [
-							'href' => '/link',
-							'target' => '_blank',
-							'title' => null,
-						],
-					],
-				],
-			],
-		],
-	];
-  }
+    public static function tagWithNullAttribute()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'link text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => '/link',
+                                'target' => '_blank',
+                                'title' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
-  public static function bulletList()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [[
-            'type' => 'bullet_list',
+    public static function bulletList()
+    {
+        return [
+            'type' => 'doc',
             'content' => [[
-                'type' => 'list_item',
+                'type' => 'bullet_list',
                 'content' => [[
-                    'type' => 'paragraph',
+                    'type' => 'list_item',
                     'content' => [[
-                        'text' => 'Item 1',
-                        'type' => 'text',
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'text' => 'Item 1',
+                            'type' => 'text',
+                        ]],
                     ]],
-                ]],
-            ], [
-                'type' => 'list_item',
-                'content' => [[
-                    'type' => 'paragraph',
+                ], [
+                    'type' => 'list_item',
                     'content' => [[
-                        'text' => 'Item 2',
-                        'type' => 'text',
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'text' => 'Item 2',
+                            'type' => 'text',
+                        ]],
                     ]],
-                ]],
-            ], [
-                'type' => 'list_item',
-                'content' => [[
-                    'type' => 'paragraph',
+                ], [
+                    'type' => 'list_item',
                     'content' => [[
-                        'text' => 'Item 3',
-                        'type' => 'text',
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'text' => 'Item 3',
+                            'type' => 'text',
+                        ]],
                     ]],
                 ]],
             ]],
-        ]],
-    ];
-  }
+        ];
+    }
 
-  public static function orderedList()
-  {
-    return  [
+    public static function orderedList()
+    {
+        return [
             'type' => 'doc',
             'content' => [[
                 'type' => 'ordered_list',
@@ -194,611 +194,612 @@ class ResolverTestData
                 ]],
             ]],
         ];
-  }
+    }
 
-  public static function complexData()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [[
-            'type' => 'paragraph',
+    public static function complexData()
+    {
+        return [
+            'type' => 'doc',
             'content' => [[
-                'text' => 'Lorem ',
-                'type' => 'text',
-            ], [
-                'text' => 'ipsum',
-                'type' => 'text',
-                'marks' => [[
-                    'type' => 'strike',
-                ]],
-            ], [
-                'text' => ' dolor sit amet, ',
-                'type' => 'text',
-            ], [
-                'text' => 'consectetur',
-                'type' => 'text',
-                'marks' => [[
-                    'type' => 'bold',
-                ]],
-            ], [
-                'text' => ' ',
-                'type' => 'text',
-            ], [
-                'text' => 'adipiscing',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'underline',
+                'type' => 'paragraph',
+                'content' => [[
+                    'text' => 'Lorem ',
+                    'type' => 'text',
+                ], [
+                    'text' => 'ipsum',
+                    'type' => 'text',
+                    'marks' => [[
+                        'type' => 'strike',
+                    ]],
+                ], [
+                    'text' => ' dolor sit amet, ',
+                    'type' => 'text',
+                ], [
+                    'text' => 'consectetur',
+                    'type' => 'text',
+                    'marks' => [[
+                        'type' => 'bold',
+                    ]],
+                ], [
+                    'text' => ' ',
+                    'type' => 'text',
+                ], [
+                    'text' => 'adipiscing',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'underline',
+                        ],
                     ],
-                ],
-            ], [
-                'text' => ' elit. Duis in ',
-                'type' => 'text',
-            ], [
-                'text' => 'sodales',
-                'type' => 'text',
-                'marks' => [[
-                    'type' => 'code',
+                ], [
+                    'text' => ' elit. Duis in ',
+                    'type' => 'text',
+                ], [
+                    'text' => 'sodales',
+                    'type' => 'text',
+                    'marks' => [[
+                        'type' => 'code',
+                    ]],
+                ], [
+                    'text' => ' metus. Sed auctor, tellus in placerat aliquet, arcu neque efficitur libero, non euismod ',
+                    'type' => 'text',
+                ], [
+                    'text' => 'metus',
+                    'type' => 'text',
+                    'marks' => [[
+                        'type' => 'italic',
+                    ]],
+                ], [
+                    'text' => ' orci eu erat',
+                    'type' => 'text',
                 ]],
-            ], [
-                'text' => ' metus. Sed auctor, tellus in placerat aliquet, arcu neque efficitur libero, non euismod ',
-                'type' => 'text',
-            ], [
-                'text' => 'metus',
-                'type' => 'text',
-                'marks' => [[
-                    'type' => 'italic',
-                ]],
-            ], [
-                'text' => ' orci eu erat',
-                'type' => 'text',
             ]],
-        ]],
-    ];
-  }
+        ];
+    }
 
-  public static function paragraphWithThreeClassAttribute()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'This is a ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'awesome',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'styled',
-                                'attrs' => [
-                                    'class' => 'test',
+    public static function paragraphWithThreeClassAttribute()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'This is a ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'awesome',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'styled',
+                                    'attrs' => [
+                                        'class' => 'test',
+                                    ],
                                 ],
                             ],
                         ],
-                    ],
-                    [
-                        'text' => ' text and this ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'renderer',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'styled',
-                                'attrs' => [
-                                    'class' => 'red',
+                        [
+                            'text' => ' text and this ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'renderer',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'styled',
+                                    'attrs' => [
+                                        'class' => 'red',
+                                    ],
                                 ],
                             ],
                         ],
-                    ],
-                    [
-                        'text' => ' is built with ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'php.',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'styled',
-                                'attrs' => [
-                                    'class' => 'test__red',
+                        [
+                            'text' => ' is built with ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'php.',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'styled',
+                                    'attrs' => [
+                                        'class' => 'test__red',
+                                    ],
                                 ],
                             ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function fullText()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 1,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Heading one',
-                        'type' => 'text',
+    public static function fullText()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 1,
                     ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sem nisi, imperdiet non ultricies at, luctus sit amet nisi.',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 2,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Heading two',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Aliquam consectetur sem et convallis hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; In tincidunt placerat velit vel lobortis.',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 3,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Heading three',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Suspendisse ultricies urna arcu, id tincidunt nibh posuere ut. Nunc dapibus, tellus sit amet fermentum eleifend, risus augue pretium massa, a imperdiet tortor ante placerat diam.',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 4,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Heading four',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Fusce non vehicula eros. Duis diam orci, efficitur porta mauris et, porttitor aliquet nisl.',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 5,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Heading five',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Integer quis euismod nulla. Nam dapibus maximus nisi, in tempor ante consequat ac. Vestibulum rutrum hendrerit ex, ac dapibus dui finibus id. Praesent molestie dictum neque vel lobortis',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 6,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Heading six',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Proin congue felis faucibus, volutpat lorem non, imperdiet lacus. Curabitur sed mattis tellus. Maecenas at aliquam odio',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'horizontal_rule',
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 1,
-                ],
-                'content' => [
-                    [
-                        'text' => 'More examples to another tags',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 2,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Blockquote',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'blockquote',
-                'content' => [
-                    [
-                        'type' => 'paragraph',
-                        'content' => [
-                            [
-                                'text' => 'This is an example of blockquote',
-                                'type' => 'text',
-                            ],
+                    'content' => [
+                        [
+                            'text' => 'Heading one',
+                            'type' => 'text',
                         ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 2,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Lists',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Unordered List:',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'bullet_list',
-                'attrs' => [
-                    'tight' => false,
-                ],
-                'content' => [
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'Item one',
-                                        'type' => 'text',
-                                    ],
-                                ],
-                            ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sem nisi, imperdiet non ultricies at, luctus sit amet nisi.',
+                            'type' => 'text',
                         ],
                     ],
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'Item two',
-                                        'type' => 'text',
-                                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 2,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Heading two',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Aliquam consectetur sem et convallis hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; In tincidunt placerat velit vel lobortis.',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 3,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Heading three',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Suspendisse ultricies urna arcu, id tincidunt nibh posuere ut. Nunc dapibus, tellus sit amet fermentum eleifend, risus augue pretium massa, a imperdiet tortor ante placerat diam.',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 4,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Heading four',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Fusce non vehicula eros. Duis diam orci, efficitur porta mauris et, porttitor aliquet nisl.',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 5,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Heading five',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Integer quis euismod nulla. Nam dapibus maximus nisi, in tempor ante consequat ac. Vestibulum rutrum hendrerit ex, ac dapibus dui finibus id. Praesent molestie dictum neque vel lobortis',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 6,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Heading six',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Proin congue felis faucibus, volutpat lorem non, imperdiet lacus. Curabitur sed mattis tellus. Maecenas at aliquam odio',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'horizontal_rule',
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 1,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'More examples to another tags',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 2,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Blockquote',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'blockquote',
+                    'content' => [
+                        [
+                            'type' => 'paragraph',
+                            'content' => [
+                                [
+                                    'text' => 'This is an example of blockquote',
+                                    'type' => 'text',
                                 ],
                             ],
                         ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Bullet List:',
-                        'type' => 'text',
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 2,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Lists',
+                            'type' => 'text',
+                        ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'bullet_list',
-                'attrs' => [
-                    'tight' => false,
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Unordered List:',
+                            'type' => 'text',
+                        ],
+                    ],
                 ],
-                'content' => [
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'Item one',
-                                        'type' => 'text',
+                [
+                    'type' => 'bullet_list',
+                    'attrs' => [
+                        'tight' => false,
+                    ],
+                    'content' => [
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'Item one',
+                                            'type' => 'text',
+                                        ],
                                     ],
                                 ],
                             ],
                         ],
-                    ],
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'Item two',
-                                        'type' => 'text',
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'Item two',
+                                            'type' => 'text',
+                                        ],
                                     ],
                                 ],
                             ],
                         ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Ordered List:',
-                        'type' => 'text',
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Bullet List:',
+                            'type' => 'text',
+                        ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'ordered_list',
-                'attrs' => [
-                    'order' => 1,
-                    'tight' => false,
-                ],
-                'content' => [
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'Item one',
-                                        'type' => 'text',
+                [
+                    'type' => 'bullet_list',
+                    'attrs' => [
+                        'tight' => false,
+                    ],
+                    'content' => [
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'Item one',
+                                            'type' => 'text',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'Item two',
+                                            'type' => 'text',
+                                        ],
                                     ],
                                 ],
                             ],
                         ],
                     ],
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'Item two',
-                                        'type' => 'text',
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Ordered List:',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'ordered_list',
+                    'attrs' => [
+                        'order' => 1,
+                        'tight' => false,
+                    ],
+                    'content' => [
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'Item one',
+                                            'type' => 'text',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'Item two',
+                                            'type' => 'text',
+                                        ],
                                     ],
                                 ],
                             ],
                         ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 2,
-                ],
-                'content' => [
-                    [
-                        'text' => 'Formats',
-                        'type' => 'text',
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 2,
                     ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Lorem ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'ipsum dolor',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'code',
-                            ],
+                    'content' => [
+                        [
+                            'text' => 'Formats',
+                            'type' => 'text',
                         ],
                     ],
-                    [
-                        'text' => ' sit amet, consectetur adipiscing elit. ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'Vestibulum',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'bold',
-                            ],
-                        ],
-                    ],
-                    [
-                        'text' => ' sem ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'nisi',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'italic',
-                            ],
-                        ],
-                    ],
-                    [
-                        'text' => ', imperdiet non ultricies at, luctus sit amet nisi.',
-                        'type' => 'text',
-                    ],
                 ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'A link to Vue.js website',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'link',
-                                'attrs' => [
-                                    'href' => 'https://vuejs.org',
-                                    'title' => null,
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Lorem ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'ipsum dolor',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'code',
                                 ],
                             ],
                         ],
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'type' => 'image',
-                        'attrs' => [
-                            'alt' => 'This is the Vue.js logo',
-                            'src' => 'https://vuejs.org/images/logo.png',
-                            'title' => null,
+                        [
+                            'text' => ' sit amet, consectetur adipiscing elit. ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'Vestibulum',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'bold',
+                                ],
+                            ],
+                        ],
+                        [
+                            'text' => ' sem ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'nisi',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'italic',
+                                ],
+                            ],
+                        ],
+                        [
+                            'text' => ', imperdiet non ultricies at, luctus sit amet nisi.',
+                            'type' => 'text',
                         ],
                     ],
                 ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 1,
-                ],
-                'content' => [
-                    [
-                        'text' => 'this is an example of fence',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'code_block',
-                'attrs' => [
-                    'params' => 'js',
-                ],
-                'content' => [
-                    [
-                        'text' => "const world = 'Hello'",
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => 1,
-                ],
-                'content' => [
-                    [
-                        'text' => 'nested lists',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'bullet_list',
-                'attrs' => [
-                    'tight' => false,
-                ],
-                'content' => [
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'list item',
-                                        'type' => 'text',
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'A link to Vue.js website',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'link',
+                                    'attrs' => [
+                                        'href' => 'https://vuejs.org',
+                                        'title' => null,
                                     ],
                                 ],
                             ],
-                            [
-                                'type' => 'bullet_list',
-                                'attrs' => [
-                                    'tight' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'image',
+                            'attrs' => [
+                                'alt' => 'This is the Vue.js logo',
+                                'src' => 'https://vuejs.org/images/logo.png',
+                                'title' => null,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 1,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'this is an example of fence',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'code_block',
+                    'attrs' => [
+                        'params' => 'js',
+                    ],
+                    'content' => [
+                        [
+                            'text' => "const world = 'Hello'",
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => 1,
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'nested lists',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'bullet_list',
+                    'attrs' => [
+                        'tight' => false,
+                    ],
+                    'content' => [
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'list item',
+                                            'type' => 'text',
+                                        ],
+                                    ],
                                 ],
-                                'content' => [
-                                    [
-                                        'type' => 'list_item',
-                                        'content' => [
-                                            [
-                                                'type' => 'paragraph',
-                                                'content' => [
-                                                    [
-                                                        'text' => 'internal list item',
-                                                        'type' => 'text',
+                                [
+                                    'type' => 'bullet_list',
+                                    'attrs' => [
+                                        'tight' => false,
+                                    ],
+                                    'content' => [
+                                        [
+                                            'type' => 'list_item',
+                                            'content' => [
+                                                [
+                                                    'type' => 'paragraph',
+                                                    'content' => [
+                                                        [
+                                                            'text' => 'internal list item',
+                                                            'type' => 'text',
+                                                        ],
                                                     ],
                                                 ],
                                             ],
@@ -807,16 +808,16 @@ class ResolverTestData
                                 ],
                             ],
                         ],
-                    ],
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => 'another list item',
-                                        'type' => 'text',
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => 'another list item',
+                                            'type' => 'text',
+                                        ],
                                     ],
                                 ],
                             ],
@@ -824,13 +825,12 @@ class ResolverTestData
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function textWithMissingAttrs()
-  {
-    return [
+    public static function textWithMissingAttrs()
+    {
+        return [
             'type' => 'doc',
             'content' => [
                 [
@@ -876,251 +876,374 @@ class ResolverTestData
                 ],
             ],
         ];
-  }
+    }
 
-  public static function textWithBrokenAttrs()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Text with ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'highlight',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'highlight',
-                                'attrs' => [
-                                    'color' => null,
-                                ],
-                            ],
+    public static function textWithBrokenAttrs()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Text with ',
+                            'type' => 'text',
                         ],
-                    ],
-                    [
-                        'text' => ' colors. And another text ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'with text',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'textStyle',
-                                'attrs' => [],
-                            ],
-                        ],
-                    ],
-                    [
-                        'text' => ' color.',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Text with ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'highlight',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'highlight',
-                                'attrs' => [
-                                    'color' => null,
-                                ],
-                            ],
-                        ],
-                    ],
-                    [
-                        'text' => ' colors. And another text ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'with text',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'textStyle',
-                            ],
-                        ],
-                    ],
-                    [
-                        'text' => ' color.',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-        ],
-    ];
-  }
-
-  public static function textWithLinksSubscriptsAndSuperscripts()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'bold',
-                            ],
-                        ],
-                        'text' => 'Lorem Ipsum',
-                    ],
-                    [
-                        'type' => 'text',
-                        'text' => ' is simply dummy text of the ',
-                    ],
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'link',
-                                'attrs' => [
-                                    'href' => 'test.com',
-                                    'uuid' => null,
-                                    'linktype' => 'url',
-                                    'target' => '_self',
-                                    'anchor' => null,
-                                    'custom' => [
-                                        'title' => 'test one',
-                                        'rel' => 'test two',
+                        [
+                            'text' => 'highlight',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'highlight',
+                                    'attrs' => [
+                                        'color' => null,
                                     ],
                                 ],
                             ],
                         ],
-                        'text' => 'printing and typesetting industry',
-                    ],
-                    [
-                        'type' => 'text',
-                        'text' => ". Lorem Ipsum has been the industry's standard dummy text ever since the ",
-                    ],
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'superscript',
+                        [
+                            'text' => ' colors. And another text ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'with text',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'textStyle',
+                                    'attrs' => [],
+                                ],
                             ],
                         ],
-                        'text' => '1500s',
+                        [
+                            'text' => ' color.',
+                            'type' => 'text',
+                        ],
                     ],
-                    [
-                        'type' => 'text',
-                        'text' => ', when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the ',
-                    ],
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'subscript',
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Text with ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'highlight',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'highlight',
+                                    'attrs' => [
+                                        'color' => null,
+                                    ],
+                                ],
                             ],
                         ],
-                        'text' => '1960s',
-                    ],
-                    [
-                        'type' => 'text',
-                        'text' => ' with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like ',
-                    ],
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'superscript',
+                        [
+                            'text' => ' colors. And another text ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'with text',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'textStyle',
+                                ],
                             ],
                         ],
-                        'text' => 'Aldus PageMaker',
-                    ],
-                    [
-                        'type' => 'text',
-                        'text' => ' including versions of ',
-                    ],
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'subscript',
-                            ],
+                        [
+                            'text' => ' color.',
+                            'type' => 'text',
                         ],
-                        'text' => 'Lorem Ipsum',
-                    ],
-                    [
-                        'type' => 'text',
-                        'text' => '.',
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function escapeHTMLMarksFromText()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Simple phrases to test escapes:',
-                        'type' => 'text',
+    public static function textWithLinksSubscriptsAndSuperscripts()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'bold',
+                                ],
+                            ],
+                            'text' => 'Lorem Ipsum',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ' is simply dummy text of the ',
+                        ],
+                        [
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'link',
+                                    'attrs' => [
+                                        'href' => 'test.com',
+                                        'uuid' => null,
+                                        'linktype' => 'url',
+                                        'target' => '_self',
+                                        'anchor' => null,
+                                        'custom' => [
+                                            'title' => 'test one',
+                                            'rel' => 'test two',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'text' => 'printing and typesetting industry',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ". Lorem Ipsum has been the industry's standard dummy text ever since the ",
+                        ],
+                        [
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'superscript',
+                                ],
+                            ],
+                            'text' => '1500s',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ', when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the ',
+                        ],
+                        [
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'subscript',
+                                ],
+                            ],
+                            'text' => '1960s',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ' with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like ',
+                        ],
+                        [
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'superscript',
+                                ],
+                            ],
+                            'text' => 'Aldus PageMaker',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ' including versions of ',
+                        ],
+                        [
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'subscript',
+                                ],
+                            ],
+                            'text' => 'Lorem Ipsum',
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => '.',
+                        ],
                     ],
                 ],
             ],
-            [
-                'type' => 'bullet_list',
-                'content' => [
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => "A dummy apostrophe's test",
-                                        'type' => 'text',
+        ];
+    }
+
+    public static function escapeHTMLMarksFromText()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Simple phrases to test escapes:',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'bullet_list',
+                    'content' => [
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => "A dummy apostrophe's test",
+                                            'type' => 'text',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => '<p>Just a tag</p>',
+                                            'type' => 'text',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'list_item',
+                            'content' => [
+                                [
+                                    'type' => 'paragraph',
+                                    'content' => [
+                                        [
+                                            'text' => '<p>Dummy & test</p>',
+                                            'type' => 'text',
+                                        ],
                                     ],
                                 ],
                             ],
                         ],
                     ],
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => '<p>Just a tag</p>',
-                                        'type' => 'text',
+                ],
+            ],
+        ];
+    }
+
+    public static function escapeAmpersandInAttributeValues()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'test',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'link',
+                                    'attrs' => [
+                                        'href' => 'https://www.storyblok.com/?foo=bar&bar=foo',
+                                        'uuid' => null,
+                                        'anchor' => null,
+                                        'target' => '_self',
+                                        'linktype' => 'url',
                                     ],
                                 ],
                             ],
                         ],
                     ],
-                    [
-                        'type' => 'list_item',
-                        'content' => [
-                            [
-                                'type' => 'paragraph',
-                                'content' => [
-                                    [
-                                        'text' => '<p>Dummy & test</p>',
-                                        'type' => 'text',
+                ],
+            ],
+        ];
+    }
+
+    public static function h1WithAnchorInTheMiddleOfText()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'heading',
+                    'attrs' => [
+                        'level' => '1',
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Title with ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'Anchor',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'anchor',
+                                    'attrs' => [
+                                        'id' => 'test1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'text' => ' in the midle',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function customAttrsInLinks()
+    {
+        return [
+            'type' => 'paragraph',
+            'content' => [
+                [
+                    'text' => 'A nice link with custom attr',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => 'www.storyblok.com',
+                                'uuid' => '300aeadc-c82d-4529-9484-f3f8f09cf9f5',
+                                'anchor' => null,
+                                'custom' => [
+                                    'rel' => 'nofollow',
+                                    'title' => 'nice test',
+                                ],
+                                'target' => '_blank',
+                                'linktype' => 'url',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function textWithAnchor()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Paragraph with anchor in the middle',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'anchor',
+                                    'attrs' => [
+                                        'id' => 'test',
                                     ],
                                 ],
                             ],
@@ -1128,294 +1251,171 @@ class ResolverTestData
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function escapeAmpersandInAttributeValues()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'test',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => "link",
-                                'attrs' => [
-                                    'href' => "https://www.storyblok.com/?foo=bar&bar=foo",
-                                    'uuid' => null,
-                                    'anchor' => null,
-                                    'target' => "_self",
-                                    'linktype' => "url",
+    public static function linkTagWithAnchor()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'link text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => '/link',
+                                'target' => '_blank',
+                                'title' => 'Any title',
+                                'anchor' => 'anchor-text',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function linkTagWithStory()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'link text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => '/link',
+                                'uuid' => '0fe06b7d-03d8-4d66-8976-9f7febace056',
+                                'target' => '_self',
+                                'linktype' => 'story',
+                                'anchor' => 'anchor-text',
+                                'story' => [
+                                    '_uid' => 'b94a6a90-1bd4-4ee0-ac14-a09310bd6a45',
+                                    'component' => 'page',
                                 ],
                             ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function h1WithAnchorInTheMiddleOfText()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => '1',
-                ],
-                'content' => [
-                    [
-                        'text' => 'Title with ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'Anchor',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'anchor',
-                                'attrs' => [
-                                    'id' => 'test1',
-                                ],
+    public static function linkTagWithoutAnchorButWithCssClass()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'text' => 'link text',
+                    'type' => 'text',
+                    'marks' => [
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => '/link',
+                                'target' => '_blank',
+                                'title' => 'Any title',
+                                'anchor' => '',
                             ],
                         ],
-                    ],
-                    [
-                        'text' => ' in the midle',
-                        'type' => 'text',
-                    ],
-                ],
-            ],
-        ],
-    ];
-  }
-
-  public static function customAttrsInLinks()
-  {
-    return [
-        'type' => 'paragraph',
-        'content' => [
-            [
-                'text' => 'A nice link with custom attr',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'link',
-                        'attrs' => [
-                            'href' => 'www.storyblok.com',
-                            'uuid' => '300aeadc-c82d-4529-9484-f3f8f09cf9f5',
-                            'anchor' => null,
-                            'custom' => [
-                                'rel' => 'nofollow',
-                                'title' => 'nice test',
+                        [
+                            'type' => 'styled',
+                            'attrs' => [
+                                'class' => 'css__class',
                             ],
-                            'target' => '_blank',
-                            'linktype' => 'url',
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function textWithAnchor()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Paragraph with anchor in the middle',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'anchor',
-                                'attrs' => [
-                                    'id' => 'test',
+    public static function paragraphWithClassAttribute()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Storyblok visual editor is ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'awesome!',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'styled',
+                                    'attrs' => [
+                                        'class' => 'highlight',
+                                    ],
                                 ],
                             ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function linkTagWithAnchor()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'text' => 'link text',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'link',
-                        'attrs' => [
-                            'href' => '/link',
-                            'target' => '_blank',
-                            'title' => 'Any title',
-                            'anchor' => 'anchor-text',
+    public static function emojiWithFallbackImage()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Text with an emoji in the end ',
+                            'type' => 'text',
                         ],
-                    ],
-                ],
-            ],
-        ],
-    ];
-  }
-
-  public static function linkTagWithStory()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'text' => 'link text',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'link',
-                        'attrs' => [
-                            'href' => '/link',
-                            'uuid' => '0fe06b7d-03d8-4d66-8976-9f7febace056',
-                            'target' => '_self',
-                            'linktype' => 'story',
-                            'anchor' => 'anchor-text',
-                            'story' => [
-                                '_uid' => 'b94a6a90-1bd4-4ee0-ac14-a09310bd6a45',
-                                'component' => 'page',
+                        [
+                            'type' => 'emoji',
+                            'attrs' => [
+                                'name' => 'trollface',
+                                'emoji' => null,
+                                'fallbackImage' => 'https://github.githubassets.com/images/icons/emoji/trollface.png',
                             ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
+        ];
+    }
 
-  public static function linkTagWithoutAnchorButWithCssClass()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'text' => 'link text',
-                'type' => 'text',
-                'marks' => [
-                    [
-                        'type' => 'link',
-                        'attrs' => [
-                            'href' => '/link',
-                            'target' => '_blank',
-                            'title' => 'Any title',
-                            'anchor' => '',
+    public static function textWithEmoji()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Text with an emoji in the end ',
+                            'type' => 'text',
                         ],
-                    ],
-                    [
-                        'type' => 'styled',
-                        'attrs' => [
-                            'class' => 'css__class',
-                        ],
-                    ],
-                ],
-            ],
-        ],
-    ];
-  }
-
-  public static function paragraphWithClassAttribute()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Storyblok visual editor is ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'text' => 'awesome!',
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'styled',
-                                'attrs' => [
-                                    'class' => 'highlight',
-                                ],
+                        [
+                            'type' => 'emoji',
+                            'attrs' => [
+                                'name' => 'smile',
+                                'emoji' => '😄',
+                                'fallbackImage' => 'https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f604.png',
                             ],
                         ],
                     ],
                 ],
             ],
-        ],
-    ];
-  }
-
-  public static function emojiWithFallbackImage()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Text with an emoji in the end ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'type' => 'emoji',
-                        'attrs' => [
-                            'name' => 'trollface',
-                            'emoji' => null,
-                            'fallbackImage' => 'https://github.githubassets.com/images/icons/emoji/trollface.png',
-                        ],
-                    ],
-                ],
-            ],
-        ],
-    ];
-  }
-
-  public static function textWithEmoji()
-  {
-    return [
-        'type' => 'doc',
-        'content' => [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'text' => 'Text with an emoji in the end ',
-                        'type' => 'text',
-                    ],
-                    [
-                        'type' => 'emoji',
-                        'attrs' => [
-                            'name' => 'smile',
-                            'emoji' => '😄',
-                            'fallbackImage' => 'https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f604.png',
-                        ],
-                    ],
-                ],
-            ],
-        ],
-    ];
-  }
+        ];
+    }
 }

--- a/tests/Fixtures/ResolverTestData.php
+++ b/tests/Fixtures/ResolverTestData.php
@@ -1,0 +1,1421 @@
+<?php
+
+namespace Storyblok\RichtextRender\Fixtures;
+
+class ResolverTestData
+{
+  public static function spanWithClassAttribute()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'text' => 'red text',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'styled',
+                        'attrs' => [
+                            'class' => 'red',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function linkTag()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'text' => 'link text',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'link',
+                        'attrs' => [
+                            'href' => '/link',
+                            'target' => '_blank',
+                            'linktype' => 'link',
+                            'title' => 'Any title',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function linkTagWithEmptyCustomAttributes()
+  {
+    return [
+		'type' => 'doc',
+		'content' => [
+			[
+				'text' => 'link text',
+				'type' => 'text',
+				'marks' => [
+					[
+						'type' => 'link',
+						'attrs' => [
+							'href' => '/link',
+							'target' => '_blank',
+							'title' => 'Any title',
+							'custom' => [],
+						],
+					],
+				],
+			],
+		],
+	];
+  }
+
+  public static function linkTagWithEmail()
+  {
+    return [
+		'type' => 'doc',
+		'content' => [
+			[
+				'text' => 'an email link',
+				'type' => 'text',
+				'marks' => [
+					[
+						'type' => 'link',
+						'attrs' => [
+							'href' => 'email@client.com',
+							'target' => '_blank',
+							'linktype' => 'email',
+							'title' => 'Any title',
+						],
+					],
+				],
+			],
+		],
+	];
+  }
+
+  public static function tagWithNullAttribute()
+  {
+    return [
+		'type' => 'doc',
+		'content' => [
+			[
+				'text' => 'link text',
+				'type' => 'text',
+				'marks' => [
+					[
+						'type' => 'link',
+						'attrs' => [
+							'href' => '/link',
+							'target' => '_blank',
+							'title' => null,
+						],
+					],
+				],
+			],
+		],
+	];
+  }
+
+  public static function bulletList()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [[
+            'type' => 'bullet_list',
+            'content' => [[
+                'type' => 'list_item',
+                'content' => [[
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'text' => 'Item 1',
+                        'type' => 'text',
+                    ]],
+                ]],
+            ], [
+                'type' => 'list_item',
+                'content' => [[
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'text' => 'Item 2',
+                        'type' => 'text',
+                    ]],
+                ]],
+            ], [
+                'type' => 'list_item',
+                'content' => [[
+                    'type' => 'paragraph',
+                    'content' => [[
+                        'text' => 'Item 3',
+                        'type' => 'text',
+                    ]],
+                ]],
+            ]],
+        ]],
+    ];
+  }
+
+  public static function orderedList()
+  {
+    return  [
+            'type' => 'doc',
+            'content' => [[
+                'type' => 'ordered_list',
+                'content' => [[
+                    'type' => 'list_item',
+                    'content' => [[
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'text' => 'Item 1',
+                            'type' => 'text',
+                        ]],
+                    ]],
+                ], [
+                    'type' => 'list_item',
+                    'content' => [[
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'text' => 'Item 2',
+                            'type' => 'text',
+                        ]],
+                    ]],
+                ], [
+                    'type' => 'list_item',
+                    'content' => [[
+                        'type' => 'paragraph',
+                        'content' => [[
+                            'text' => 'Item 3',
+                            'type' => 'text',
+                        ]],
+                    ]],
+                ]],
+            ]],
+        ];
+  }
+
+  public static function complexData()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [[
+            'type' => 'paragraph',
+            'content' => [[
+                'text' => 'Lorem ',
+                'type' => 'text',
+            ], [
+                'text' => 'ipsum',
+                'type' => 'text',
+                'marks' => [[
+                    'type' => 'strike',
+                ]],
+            ], [
+                'text' => ' dolor sit amet, ',
+                'type' => 'text',
+            ], [
+                'text' => 'consectetur',
+                'type' => 'text',
+                'marks' => [[
+                    'type' => 'bold',
+                ]],
+            ], [
+                'text' => ' ',
+                'type' => 'text',
+            ], [
+                'text' => 'adipiscing',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'underline',
+                    ],
+                ],
+            ], [
+                'text' => ' elit. Duis in ',
+                'type' => 'text',
+            ], [
+                'text' => 'sodales',
+                'type' => 'text',
+                'marks' => [[
+                    'type' => 'code',
+                ]],
+            ], [
+                'text' => ' metus. Sed auctor, tellus in placerat aliquet, arcu neque efficitur libero, non euismod ',
+                'type' => 'text',
+            ], [
+                'text' => 'metus',
+                'type' => 'text',
+                'marks' => [[
+                    'type' => 'italic',
+                ]],
+            ], [
+                'text' => ' orci eu erat',
+                'type' => 'text',
+            ]],
+        ]],
+    ];
+  }
+
+  public static function paragraphWithThreeClassAttribute()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'This is a ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'awesome',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'styled',
+                                'attrs' => [
+                                    'class' => 'test',
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' text and this ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'renderer',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'styled',
+                                'attrs' => [
+                                    'class' => 'red',
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' is built with ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'php.',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'styled',
+                                'attrs' => [
+                                    'class' => 'test__red',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function fullText()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 1,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Heading one',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sem nisi, imperdiet non ultricies at, luctus sit amet nisi.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 2,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Heading two',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Aliquam consectetur sem et convallis hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; In tincidunt placerat velit vel lobortis.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 3,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Heading three',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Suspendisse ultricies urna arcu, id tincidunt nibh posuere ut. Nunc dapibus, tellus sit amet fermentum eleifend, risus augue pretium massa, a imperdiet tortor ante placerat diam.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 4,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Heading four',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Fusce non vehicula eros. Duis diam orci, efficitur porta mauris et, porttitor aliquet nisl.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 5,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Heading five',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Integer quis euismod nulla. Nam dapibus maximus nisi, in tempor ante consequat ac. Vestibulum rutrum hendrerit ex, ac dapibus dui finibus id. Praesent molestie dictum neque vel lobortis',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 6,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Heading six',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Proin congue felis faucibus, volutpat lorem non, imperdiet lacus. Curabitur sed mattis tellus. Maecenas at aliquam odio',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'horizontal_rule',
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 1,
+                ],
+                'content' => [
+                    [
+                        'text' => 'More examples to another tags',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 2,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Blockquote',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'blockquote',
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [
+                            [
+                                'text' => 'This is an example of blockquote',
+                                'type' => 'text',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 2,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Lists',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Unordered List:',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'bullet_list',
+                'attrs' => [
+                    'tight' => false,
+                ],
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'Item one',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'Item two',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Bullet List:',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'bullet_list',
+                'attrs' => [
+                    'tight' => false,
+                ],
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'Item one',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'Item two',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Ordered List:',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'ordered_list',
+                'attrs' => [
+                    'order' => 1,
+                    'tight' => false,
+                ],
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'Item one',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'Item two',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 2,
+                ],
+                'content' => [
+                    [
+                        'text' => 'Formats',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Lorem ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'ipsum dolor',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'code',
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' sit amet, consectetur adipiscing elit. ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'Vestibulum',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'bold',
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' sem ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'nisi',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'italic',
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ', imperdiet non ultricies at, luctus sit amet nisi.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'A link to Vue.js website',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'link',
+                                'attrs' => [
+                                    'href' => 'https://vuejs.org',
+                                    'title' => null,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'image',
+                        'attrs' => [
+                            'alt' => 'This is the Vue.js logo',
+                            'src' => 'https://vuejs.org/images/logo.png',
+                            'title' => null,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 1,
+                ],
+                'content' => [
+                    [
+                        'text' => 'this is an example of fence',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'code_block',
+                'attrs' => [
+                    'params' => 'js',
+                ],
+                'content' => [
+                    [
+                        'text' => "const world = 'Hello'",
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => 1,
+                ],
+                'content' => [
+                    [
+                        'text' => 'nested lists',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'bullet_list',
+                'attrs' => [
+                    'tight' => false,
+                ],
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'list item',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type' => 'bullet_list',
+                                'attrs' => [
+                                    'tight' => false,
+                                ],
+                                'content' => [
+                                    [
+                                        'type' => 'list_item',
+                                        'content' => [
+                                            [
+                                                'type' => 'paragraph',
+                                                'content' => [
+                                                    [
+                                                        'text' => 'internal list item',
+                                                        'type' => 'text',
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => 'another list item',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function textWithMissingAttrs()
+  {
+    return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'text' => 'Text with ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'highlight',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'highlight',
+                                    'attrs' => [
+                                        'color' => '',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'text' => ' colors. And another text ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'text' => 'with text',
+                            'type' => 'text',
+                            'marks' => [
+                                [
+                                    'type' => 'textStyle',
+                                    'attrs' => [
+                                        'color' => null,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'text' => ' color.',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+  }
+
+  public static function textWithBrokenAttrs()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Text with ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'highlight',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'highlight',
+                                'attrs' => [
+                                    'color' => null,
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' colors. And another text ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'with text',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'textStyle',
+                                'attrs' => [],
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' color.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Text with ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'highlight',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'highlight',
+                                'attrs' => [
+                                    'color' => null,
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' colors. And another text ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'with text',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'textStyle',
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' color.',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function textWithLinksSubscriptsAndSuperscripts()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'bold',
+                            ],
+                        ],
+                        'text' => 'Lorem Ipsum',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' is simply dummy text of the ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'link',
+                                'attrs' => [
+                                    'href' => 'test.com',
+                                    'uuid' => null,
+                                    'linktype' => 'url',
+                                    'target' => '_self',
+                                    'anchor' => null,
+                                    'custom' => [
+                                        'title' => 'test one',
+                                        'rel' => 'test two',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'text' => 'printing and typesetting industry',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ". Lorem Ipsum has been the industry's standard dummy text ever since the ",
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'superscript',
+                            ],
+                        ],
+                        'text' => '1500s',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ', when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'subscript',
+                            ],
+                        ],
+                        'text' => '1960s',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'superscript',
+                            ],
+                        ],
+                        'text' => 'Aldus PageMaker',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' including versions of ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'subscript',
+                            ],
+                        ],
+                        'text' => 'Lorem Ipsum',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => '.',
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function escapeHTMLMarksFromText()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Simple phrases to test escapes:',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'bullet_list',
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => "A dummy apostrophe's test",
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => '<p>Just a tag</p>',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'text' => '<p>Dummy & test</p>',
+                                        'type' => 'text',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function escapeAmpersandInAttributeValues()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'test',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => "link",
+                                'attrs' => [
+                                    'href' => "https://www.storyblok.com/?foo=bar&bar=foo",
+                                    'uuid' => null,
+                                    'anchor' => null,
+                                    'target' => "_self",
+                                    'linktype' => "url",
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function h1WithAnchorInTheMiddleOfText()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'heading',
+                'attrs' => [
+                    'level' => '1',
+                ],
+                'content' => [
+                    [
+                        'text' => 'Title with ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'Anchor',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'anchor',
+                                'attrs' => [
+                                    'id' => 'test1',
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'text' => ' in the midle',
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function customAttrsInLinks()
+  {
+    return [
+        'type' => 'paragraph',
+        'content' => [
+            [
+                'text' => 'A nice link with custom attr',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'link',
+                        'attrs' => [
+                            'href' => 'www.storyblok.com',
+                            'uuid' => '300aeadc-c82d-4529-9484-f3f8f09cf9f5',
+                            'anchor' => null,
+                            'custom' => [
+                                'rel' => 'nofollow',
+                                'title' => 'nice test',
+                            ],
+                            'target' => '_blank',
+                            'linktype' => 'url',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function textWithAnchor()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Paragraph with anchor in the middle',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'anchor',
+                                'attrs' => [
+                                    'id' => 'test',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function linkTagWithAnchor()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'text' => 'link text',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'link',
+                        'attrs' => [
+                            'href' => '/link',
+                            'target' => '_blank',
+                            'title' => 'Any title',
+                            'anchor' => 'anchor-text',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function linkTagWithStory()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'text' => 'link text',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'link',
+                        'attrs' => [
+                            'href' => '/link',
+                            'uuid' => '0fe06b7d-03d8-4d66-8976-9f7febace056',
+                            'target' => '_self',
+                            'linktype' => 'story',
+                            'anchor' => 'anchor-text',
+                            'story' => [
+                                '_uid' => 'b94a6a90-1bd4-4ee0-ac14-a09310bd6a45',
+                                'component' => 'page',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function linkTagWithoutAnchorButWithCssClass()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'text' => 'link text',
+                'type' => 'text',
+                'marks' => [
+                    [
+                        'type' => 'link',
+                        'attrs' => [
+                            'href' => '/link',
+                            'target' => '_blank',
+                            'title' => 'Any title',
+                            'anchor' => '',
+                        ],
+                    ],
+                    [
+                        'type' => 'styled',
+                        'attrs' => [
+                            'class' => 'css__class',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function paragraphWithClassAttribute()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Storyblok visual editor is ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'text' => 'awesome!',
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'styled',
+                                'attrs' => [
+                                    'class' => 'highlight',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function emojiWithFallbackImage()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Text with an emoji in the end ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'type' => 'emoji',
+                        'attrs' => [
+                            'name' => 'trollface',
+                            'emoji' => null,
+                            'fallbackImage' => 'https://github.githubassets.com/images/icons/emoji/trollface.png',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+
+  public static function textWithEmoji()
+  {
+    return [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'text' => 'Text with an emoji in the end ',
+                        'type' => 'text',
+                    ],
+                    [
+                        'type' => 'emoji',
+                        'attrs' => [
+                            'name' => 'smile',
+                            'emoji' => '😄',
+                            'fallbackImage' => 'https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f604.png',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+  }
+}

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -4,6 +4,7 @@ namespace Storyblok\RichtextRender;
 
 use PHPUnit\Framework\TestCase;
 use Storyblok\RichtextRender\Utils\Render;
+use Storyblok\RichtextRender\Utils\Utils;
 
 /**
  * @internal
@@ -14,9 +15,7 @@ final class RenderTest extends TestCase
 {
     public function testEscapeHml()
     {
-        $renderer = new Render();
-
-        self::assertSame('&gt;', $renderer->escapeHTMl('>'));
+        self::assertSame('&gt;', Utils::escapeHTMl('>'));
     }
 
     /**

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -31,7 +31,7 @@ final class RenderTest extends TestCase
         self::assertSame($expected, $renderer->renderOpeningTag($input));
     }
 
-    public function provideRenderOpeningTagCases()
+    public function provideRenderOpeningTagCases(): iterable
     {
         return [
             'without argument' => [
@@ -78,7 +78,7 @@ final class RenderTest extends TestCase
         self::assertSame($expected, $renderer->renderClosingTag($input));
     }
 
-    public function provideRenderClosingTagCases()
+    public function provideRenderClosingTagCases(): iterable
     {
         return [
             'without argument' => [

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -6,9 +6,8 @@
 
 namespace Storyblok\RichtextRender;
 
-use Storyblok\RichtextRender\Fixtures\ResolverTestData;
-
 use PHPUnit\Framework\TestCase;
+use Storyblok\RichtextRender\Fixtures\ResolverTestData;
 
 /**
  * @internal
@@ -599,20 +598,11 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data =  ResolverTestData::textWithBrokenAttrs();
+        $data = ResolverTestData::textWithBrokenAttrs();
 
         $expected = '<p>Text with highlight colors. And another text with text color.</p><p>Text with highlight colors. And another text with text color.</p>';
 
         self::assertSame($expected, $resolver->render((object) $data));
-    }
-
-    private function getTag($tag)
-    {
-        return static function () use ($tag) {
-            return [
-                'tag' => $tag,
-            ];
-        };
     }
 
     public function testTextWithLinksSubscriptsAndSuperscripts()
@@ -646,5 +636,14 @@ final class ResolverTest extends TestCase
         $expected = '<p><a href="https://www.storyblok.com/?foo=bar&amp;bar=foo" target="_self">test</a></p>';
 
         self::assertSame($expected, $resolver->render((object) $data));
+    }
+
+    private function getTag($tag)
+    {
+        return static function () use ($tag) {
+            return [
+                'tag' => $tag,
+            ];
+        };
     }
 }

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -643,7 +643,7 @@ final class ResolverTest extends TestCase
 
         $data = ResolverTestData::escapeAmpersandInAttributeValues();
 
-        $expected = '<p><a href="https://www.storyblok.com/?foo=bar&bar=foo" target="_self">test</a></p>';
+        $expected = '<p><a href="https://www.storyblok.com/?foo=bar&amp;bar=foo" target="_self">test</a></p>';
 
         self::assertSame($expected, $resolver->render((object) $data));
     }

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -6,6 +6,8 @@
 
 namespace Storyblok\RichtextRender;
 
+use Storyblok\RichtextRender\Fixtures\ResolverTestData;
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,23 +21,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'red text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'styled',
-                            'attrs' => [
-                                'class' => 'red',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::spanWithClassAttribute();
 
         $expected = '<span class="red">red text</span>';
 
@@ -86,26 +72,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'link text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => '/link',
-                                'target' => '_blank',
-                                'linktype' => 'link',
-                                'title' => 'Any title',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::linkTag();
 
         $expected = '<a href="/link" target="_blank" title="Any title">link text</a>';
 
@@ -148,26 +115,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'link text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => '/link',
-                                'target' => '_blank',
-                                'title' => 'Any title',
-                                'custom' => [],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::linkTagWithEmptyCustomAttributes();
 
         $expected = '<a href="/link" target="_blank" title="Any title">link text</a>';
 
@@ -178,26 +126,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'an email link',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => 'email@client.com',
-                                'target' => '_blank',
-                                'linktype' => 'email',
-                                'title' => 'Any title',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::linkTagWithEmail();
 
         $expected = '<a href="mailto:email@client.com" target="_blank" title="Any title">an email link</a>';
 
@@ -208,25 +137,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'link text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => '/link',
-                                'target' => '_blank',
-                                'title' => null,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::tagWithNullAttribute();
 
         $expected = '<a href="/link" target="_blank">link text</a>';
 
@@ -249,6 +160,7 @@ final class ResolverTest extends TestCase
                         ]],
                 ]],
         ];
+
         $expected = '<pre><code>code</code></pre>';
 
         self::assertSame($expected, $resolver->render((object) $data));
@@ -298,40 +210,8 @@ final class ResolverTest extends TestCase
     public function testRenderBulletList()
     {
         $resolver = new Resolver();
-        $data = [
-            'type' => 'doc',
-            'content' => [[
-                'type' => 'bullet_list',
-                'content' => [[
-                    'type' => 'list_item',
-                    'content' => [[
-                        'type' => 'paragraph',
-                        'content' => [[
-                            'text' => 'Item 1',
-                            'type' => 'text',
-                        ]],
-                    ]],
-                ], [
-                    'type' => 'list_item',
-                    'content' => [[
-                        'type' => 'paragraph',
-                        'content' => [[
-                            'text' => 'Item 2',
-                            'type' => 'text',
-                        ]],
-                    ]],
-                ], [
-                    'type' => 'list_item',
-                    'content' => [[
-                        'type' => 'paragraph',
-                        'content' => [[
-                            'text' => 'Item 3',
-                            'type' => 'text',
-                        ]],
-                    ]],
-                ]],
-            ]],
-        ];
+
+        $data = ResolverTestData::bulletList();
 
         $expected = '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li><li><p>Item 3</p></li></ul>';
 
@@ -341,40 +221,8 @@ final class ResolverTest extends TestCase
     public function testRenderOrderedList()
     {
         $resolver = new Resolver();
-        $data = [
-            'type' => 'doc',
-            'content' => [[
-                'type' => 'ordered_list',
-                'content' => [[
-                    'type' => 'list_item',
-                    'content' => [[
-                        'type' => 'paragraph',
-                        'content' => [[
-                            'text' => 'Item 1',
-                            'type' => 'text',
-                        ]],
-                    ]],
-                ], [
-                    'type' => 'list_item',
-                    'content' => [[
-                        'type' => 'paragraph',
-                        'content' => [[
-                            'text' => 'Item 2',
-                            'type' => 'text',
-                        ]],
-                    ]],
-                ], [
-                    'type' => 'list_item',
-                    'content' => [[
-                        'type' => 'paragraph',
-                        'content' => [[
-                            'text' => 'Item 3',
-                            'type' => 'text',
-                        ]],
-                    ]],
-                ]],
-            ]],
-        ];
+
+        $data = ResolverTestData::orderedList();
 
         $expected = '<ol><li><p>Item 1</p></li><li><p>Item 2</p></li><li><p>Item 3</p></li></ol>';
 
@@ -385,63 +233,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [[
-                'type' => 'paragraph',
-                'content' => [[
-                    'text' => 'Lorem ',
-                    'type' => 'text',
-                ], [
-                    'text' => 'ipsum',
-                    'type' => 'text',
-                    'marks' => [[
-                        'type' => 'strike',
-                    ]],
-                ], [
-                    'text' => ' dolor sit amet, ',
-                    'type' => 'text',
-                ], [
-                    'text' => 'consectetur',
-                    'type' => 'text',
-                    'marks' => [[
-                        'type' => 'bold',
-                    ]],
-                ], [
-                    'text' => ' ',
-                    'type' => 'text',
-                ], [
-                    'text' => 'adipiscing',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'underline',
-                        ],
-                    ],
-                ], [
-                    'text' => ' elit. Duis in ',
-                    'type' => 'text',
-                ], [
-                    'text' => 'sodales',
-                    'type' => 'text',
-                    'marks' => [[
-                        'type' => 'code',
-                    ]],
-                ], [
-                    'text' => ' metus. Sed auctor, tellus in placerat aliquet, arcu neque efficitur libero, non euismod ',
-                    'type' => 'text',
-                ], [
-                    'text' => 'metus',
-                    'type' => 'text',
-                    'marks' => [[
-                        'type' => 'italic',
-                    ]],
-                ], [
-                    'text' => ' orci eu erat',
-                    'type' => 'text',
-                ]],
-            ]],
-        ];
+        $data = ResolverTestData::complexData();
 
         $expected = '<p>Lorem <strike>ipsum</strike> dolor sit amet, <b>consectetur</b> <u>adipiscing</u> elit. Duis in <code>sodales</code> metus. Sed auctor, tellus in placerat aliquet, arcu neque efficitur libero, non euismod <i>metus</i> orci eu erat</p>';
 
@@ -519,26 +311,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'link text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => '/link',
-                                'target' => '_blank',
-                                'title' => 'Any title',
-                                'anchor' => 'anchor-text',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::linkTagWithAnchor();
 
         $expected = '<a href="/link#anchor-text" target="_blank" title="Any title">link text</a>';
 
@@ -549,31 +322,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'link text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => '/link',
-                                'uuid' => '0fe06b7d-03d8-4d66-8976-9f7febace056',
-                                'target' => '_self',
-                                'linktype' => 'story',
-                                'anchor' => 'anchor-text',
-                                'story' => [
-                                    '_uid' => 'b94a6a90-1bd4-4ee0-ac14-a09310bd6a45',
-                                    'component' => 'page',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::linkTagWithStory();
 
         $expected = '<a href="/link#anchor-text" target="_self">link text</a>';
 
@@ -614,32 +363,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'text' => 'link text',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => '/link',
-                                'target' => '_blank',
-                                'title' => 'Any title',
-                                'anchor' => '',
-                            ],
-                        ],
-                        [
-                            'type' => 'styled',
-                            'attrs' => [
-                                'class' => 'css__class',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::linkTagWithoutAnchorButWithCssClass();
 
         $expected = '<a href="/link" target="_blank" title="Any title"><span class="css__class">link text</span></a>';
 
@@ -650,32 +374,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Storyblok visual editor is ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'awesome!',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'styled',
-                                    'attrs' => [
-                                        'class' => 'highlight',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::paragraphWithClassAttribute();
 
         $expected = '<p>Storyblok visual editor is <span class="highlight">awesome!</span></p>';
 
@@ -686,64 +385,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'This is a ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'awesome',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'styled',
-                                    'attrs' => [
-                                        'class' => 'test',
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' text and this ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'renderer',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'styled',
-                                    'attrs' => [
-                                        'class' => 'red',
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' is built with ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'php.',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'styled',
-                                    'attrs' => [
-                                        'class' => 'test__red',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::paragraphWithThreeClassAttribute();
 
         $expected = '<p>This is a <span class="test">awesome</span> text and this <span class="red">renderer</span> is built with <span class="test__red">php.</span></p>';
 
@@ -754,511 +396,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 1,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Heading one',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sem nisi, imperdiet non ultricies at, luctus sit amet nisi.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 2,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Heading two',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Aliquam consectetur sem et convallis hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; In tincidunt placerat velit vel lobortis.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 3,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Heading three',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Suspendisse ultricies urna arcu, id tincidunt nibh posuere ut. Nunc dapibus, tellus sit amet fermentum eleifend, risus augue pretium massa, a imperdiet tortor ante placerat diam.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 4,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Heading four',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Fusce non vehicula eros. Duis diam orci, efficitur porta mauris et, porttitor aliquet nisl.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 5,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Heading five',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Integer quis euismod nulla. Nam dapibus maximus nisi, in tempor ante consequat ac. Vestibulum rutrum hendrerit ex, ac dapibus dui finibus id. Praesent molestie dictum neque vel lobortis',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 6,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Heading six',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Proin congue felis faucibus, volutpat lorem non, imperdiet lacus. Curabitur sed mattis tellus. Maecenas at aliquam odio',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'horizontal_rule',
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 1,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'More examples to another tags',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 2,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Blockquote',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'blockquote',
-                    'content' => [
-                        [
-                            'type' => 'paragraph',
-                            'content' => [
-                                [
-                                    'text' => 'This is an example of blockquote',
-                                    'type' => 'text',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 2,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Lists',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Unordered List:',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'bullet_list',
-                    'attrs' => [
-                        'tight' => false,
-                    ],
-                    'content' => [
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'Item one',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'Item two',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Bullet List:',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'bullet_list',
-                    'attrs' => [
-                        'tight' => false,
-                    ],
-                    'content' => [
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'Item one',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'Item two',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Ordered List:',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'ordered_list',
-                    'attrs' => [
-                        'order' => 1,
-                        'tight' => false,
-                    ],
-                    'content' => [
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'Item one',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'Item two',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 2,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Formats',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Lorem ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'ipsum dolor',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'code',
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' sit amet, consectetur adipiscing elit. ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'Vestibulum',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'bold',
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' sem ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'nisi',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'italic',
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ', imperdiet non ultricies at, luctus sit amet nisi.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'A link to Vue.js website',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'link',
-                                    'attrs' => [
-                                        'href' => 'https://vuejs.org',
-                                        'title' => null,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'type' => 'image',
-                            'attrs' => [
-                                'alt' => 'This is the Vue.js logo',
-                                'src' => 'https://vuejs.org/images/logo.png',
-                                'title' => null,
-                            ],
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 1,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'this is an example of fence',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'code_block',
-                    'attrs' => [
-                        'params' => 'js',
-                    ],
-                    'content' => [
-                        [
-                            'text' => "const world = 'Hello'",
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => 1,
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'nested lists',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'bullet_list',
-                    'attrs' => [
-                        'tight' => false,
-                    ],
-                    'content' => [
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'list item',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                                [
-                                    'type' => 'bullet_list',
-                                    'attrs' => [
-                                        'tight' => false,
-                                    ],
-                                    'content' => [
-                                        [
-                                            'type' => 'list_item',
-                                            'content' => [
-                                                [
-                                                    'type' => 'paragraph',
-                                                    'content' => [
-                                                        [
-                                                            'text' => 'internal list item',
-                                                            'type' => 'text',
-                                                        ],
-                                                    ],
-                                                ],
-                                            ],
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'type' => 'list_item',
-                            'content' => [
-                                [
-                                    'type' => 'paragraph',
-                                    'content' => [
-                                        [
-                                            'text' => 'another list item',
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::fullText();
 
         $expected = '<h1>Heading one</h1><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sem nisi, imperdiet non ultricies at, luctus sit amet nisi.</p><h2>Heading two</h2><p>Aliquam consectetur sem et convallis hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; In tincidunt placerat velit vel lobortis.</p><h3>Heading three</h3><p>Suspendisse ultricies urna arcu, id tincidunt nibh posuere ut. Nunc dapibus, tellus sit amet fermentum eleifend, risus augue pretium massa, a imperdiet tortor ante placerat diam.</p><h4>Heading four</h4><p>Fusce non vehicula eros. Duis diam orci, efficitur porta mauris et, porttitor aliquet nisl.</p><h5>Heading five</h5><p>Integer quis euismod nulla. Nam dapibus maximus nisi, in tempor ante consequat ac. Vestibulum rutrum hendrerit ex, ac dapibus dui finibus id. Praesent molestie dictum neque vel lobortis</p><h6>Heading six</h6><p>Proin congue felis faucibus, volutpat lorem non, imperdiet lacus. Curabitur sed mattis tellus. Maecenas at aliquam odio</p><hr /><h1>More examples to another tags</h1><h2>Blockquote</h2><blockquote><p>This is an example of blockquote</p></blockquote><h2>Lists</h2><p>Unordered List:</p><ul><li><p>Item one</p></li><li><p>Item two</p></li></ul><p>Bullet List:</p><ul><li><p>Item one</p></li><li><p>Item two</p></li></ul><p>Ordered List:</p><ol><li><p>Item one</p></li><li><p>Item two</p></li></ol><h2>Formats</h2><p>Lorem <code>ipsum dolor</code> sit amet, consectetur adipiscing elit. <b>Vestibulum</b> sem <i>nisi</i>, imperdiet non ultricies at, luctus sit amet nisi.</p><p><a href="https://vuejs.org">A link to Vue.js website</a></p><p><img alt="This is the Vue.js logo" src="https://vuejs.org/images/logo.png" /></p><h1>this is an example of fence</h1><pre><code params="js">const world = &#039;Hello&#039;</code></pre><h1>nested lists</h1><ul><li><p>list item</p><ul><li><p>internal list item</p></li></ul></li><li><p>another list item</p></li></ul>';
 
@@ -1317,28 +455,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Text with an emoji in the end ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'type' => 'emoji',
-                            'attrs' => [
-                                'name' => 'smile',
-                                'emoji' => '😄',
-                                'fallbackImage' => 'https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f604.png',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::textWithEmoji();
 
         $expected = '<p>Text with an emoji in the end <span data-type="emoji" data-name="smile" emoji="😄">😄</span></p>';
 
@@ -1349,28 +466,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Text with an emoji in the end ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'type' => 'emoji',
-                            'attrs' => [
-                                'name' => 'trollface',
-                                'emoji' => null,
-                                'fallbackImage' => 'https://github.githubassets.com/images/icons/emoji/trollface.png',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::emojiWithFallbackImage();
 
         $expected = '<p>Text with an emoji in the end <span data-type="emoji" data-name="trollface"><img src="https://github.githubassets.com/images/icons/emoji/trollface.png" draggable="false" loading="lazy" align="absmiddle" /></span></p>';
 
@@ -1435,28 +531,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Paragraph with anchor in the middle',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'anchor',
-                                    'attrs' => [
-                                        'id' => 'test',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::textWithAnchor();
 
         $expected = '<p><span id="test">Paragraph with anchor in the middle</span></p>';
 
@@ -1467,31 +542,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'paragraph',
-            'content' => [
-                [
-                    'text' => 'A nice link with custom attr',
-                    'type' => 'text',
-                    'marks' => [
-                        [
-                            'type' => 'link',
-                            'attrs' => [
-                                'href' => 'www.storyblok.com',
-                                'uuid' => '300aeadc-c82d-4529-9484-f3f8f09cf9f5',
-                                'anchor' => null,
-                                'custom' => [
-                                    'rel' => 'nofollow',
-                                    'title' => 'nice test',
-                                ],
-                                'target' => '_blank',
-                                'linktype' => 'url',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::customAttrsInLinks();
 
         $expected = '<a href="www.storyblok.com" uuid="300aeadc-c82d-4529-9484-f3f8f09cf9f5" target="_blank" rel="nofollow" title="nice test">A nice link with custom attr</a>';
 
@@ -1502,39 +553,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'heading',
-                    'attrs' => [
-                        'level' => '1',
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Title with ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'Anchor',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'anchor',
-                                    'attrs' => [
-                                        'id' => 'test1',
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' in the midle',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::h1WithAnchorInTheMiddleOfText();
 
         $expected = '<h1>Title with <span id="test1">Anchor</span> in the midle</h1>';
 
@@ -1569,52 +588,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Text with ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'highlight',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'highlight',
-                                    'attrs' => [
-                                        'color' => '',
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' colors. And another text ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'with text',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'textStyle',
-                                    'attrs' => [
-                                        'color' => null,
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' color.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data = ResolverTestData::textWithMissingAttrs();
 
         $expected = '<p>Text with highlight colors. And another text with text color.</p>';
 
@@ -1625,88 +599,7 @@ final class ResolverTest extends TestCase
     {
         $resolver = new Resolver();
 
-        $data = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Text with ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'highlight',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'highlight',
-                                    'attrs' => [
-                                        'color' => null,
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' colors. And another text ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'with text',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'textStyle',
-                                    'attrs' => [],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' color.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'content' => [
-                        [
-                            'text' => 'Text with ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'highlight',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'highlight',
-                                    'attrs' => [
-                                        'color' => null,
-                                    ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' colors. And another text ',
-                            'type' => 'text',
-                        ],
-                        [
-                            'text' => 'with text',
-                            'type' => 'text',
-                            'marks' => [
-                                [
-                                    'type' => 'textStyle',
-                                ],
-                            ],
-                        ],
-                        [
-                            'text' => ' color.',
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $data =  ResolverTestData::textWithBrokenAttrs();
 
         $expected = '<p>Text with highlight colors. And another text with text color.</p><p>Text with highlight colors. And another text with text color.</p>';
 
@@ -1720,5 +613,38 @@ final class ResolverTest extends TestCase
                 'tag' => $tag,
             ];
         };
+    }
+
+    public function testTextWithLinksSubscriptsAndSuperscripts()
+    {
+        $resolver = new Resolver();
+
+        $data = ResolverTestData::textWithLinksSubscriptsAndSuperscripts();
+
+        $expected = '<p><b>Lorem Ipsum</b> is simply dummy text of the <a href="test.com" target="_self" title="test one" rel="test two">printing and typesetting industry</a>. Lorem Ipsum has been the industry&#039;s standard dummy text ever since the <sup>1500s</sup>, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the <sub>1960s</sub> with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like <sup>Aldus PageMaker</sup> including versions of <sub>Lorem Ipsum</sub>.</p>';
+
+        self::assertSame($expected, $resolver->render((object) $data));
+    }
+
+    public function testEscapeHTMLMarksFromText()
+    {
+        $resolver = new Resolver();
+
+        $data = ResolverTestData::escapeHTMLMarksFromText();
+
+        $expected = '<p>Simple phrases to test escapes:</p><ul><li><p>A dummy apostrophe&#039;s test</p></li><li><p>&lt;p&gt;Just a tag&lt;/p&gt;</p></li><li><p>&lt;p&gt;Dummy &amp; test&lt;/p&gt;</p></li></ul>';
+
+        self::assertSame($expected, $resolver->render((object) $data));
+    }
+
+    public function testEscapeAmpersandInAttributeValues()
+    {
+        $resolver = new Resolver();
+
+        $data = ResolverTestData::escapeAmpersandInAttributeValues();
+
+        $expected = '<p><a href="https://www.storyblok.com/?foo=bar&bar=foo" target="_self">test</a></p>';
+
+        self::assertSame($expected, $resolver->render((object) $data));
     }
 }


### PR DESCRIPTION
## Pull request type

Jira Link: [INT-998](https://storyblok.atlassian.net/browse/INT-998)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->
Please use [gitmoji](https://gitmoji.dev/) in your PR NAME to indicate your change:

- [x] ✨ Feature <!-- needs 💅 ✅ 🧑‍🤝‍🧑 -->
- [x] ♻️ Refactoring (no functional changes, no api changes)  <!-- needs ✅ 💅 -->
  
## How to test this PR

You can run the unit tests with `composer run test` or try to use in your php application.

## What is the new behavior?
- Now `href` attributes of all links will have the string parsed by the HTML escape function

## Other info:
You can see the reason fot this feature in this issue #23 

[INT-998]: https://storyblok.atlassian.net/browse/INT-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ