### PR TITLE
feat(rich-text): render optimized images with SB Image Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage/
 .DS_Store
 .AppleDouble
 .LSOverride
+.idea
+.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -56,6 +56,55 @@ $data = [
 
 $resolver->render($data) # renders a html string: '<hr />'
 ```
+### Optimizing images
+
+You can instruct the richtext resolver to optimize images using [Storyblok Image Service](https://www.storyblok.com/docs/image-service)
+passing the option `optimizeImages => true`.
+
+**Example**
+
+```php
+$resolver->render($data, ['optimizeImages' => true])
+```
+
+Also, it is possible to customize this option passing an array.
+All properties are optional and will be applied to each image (hosted in Storyblok) in the field. External images will be ignored.
+
+**Example**
+
+```php
+$options = [ 
+  'optimizeImages' => [
+    'class' => 'w-full my-8 border-b border-black',
+    'width' => 640, // image width
+    'height' => 360, // image height
+    'loading' => 'lazy', // 'lazy' | 'eager'
+    'filters' => [
+      'blur' => 0, // 0 to 100
+      'brightness' => 0, // -100 to 100
+      'fill' => 'transparent', // Or any hexadecimal value like FFCC99
+      'format' => 'webp', // 'webp' | 'jpeg' | 'png'
+      'grayscale' => false,
+      'quality' => 95, // 0 to 100
+      'rotate' => 0 // 0 | 90 | 180 | 270
+    ],
+    // srcset accepts an array with image widths. 
+    // Example: [720, 1024, 1533] 
+    // will render srcset="//../m/720x0 720w", "//../m/1024x0 1024w", "//../m/1533x0 1280w"
+    // Also accept an array to pass width and height. 
+    // Example: [[720,500], 1024, [1500, 1000]] 
+    // will render srcset="//../m/720x500 720w", "//../m/1024x0 1024w", "//../m/1280x0 1280w"
+    'srcset' => [720, 1024, 1533], 
+    'sizes' => [
+      '(max-width: 767px) 100vw',
+      '(max-width: 1024px) 768px',
+      '1500px'
+    ]
+  ]
+]
+
+$resolver->render($data, ['optimizeImages' => $options])
+```
 
 ### How to define a custom schema for resolver?
 

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -29,13 +29,17 @@ class Resolver
         $this->nodes = $schema->getNodes();
     }
 
-    public function render($data)
+    public function render($data, $options = [])
     {
         $html = '';
         $data = (array) $data;
 
         foreach ($data['content'] as $node) {
             $html .= $this->renderNode($node);
+        }
+
+        if ($options['optimizeImages'] ?? false) {
+            $html = $this->optimizeImages($html, $options['optimizeImages']);
         }
 
         return $html;
@@ -119,5 +123,153 @@ class Resolver
         }
 
         return null;
+    }
+
+    protected function optimizeImages($html, $options)
+    {
+        $w = 0;
+        $h = 0;
+        $imageAttributes = '';
+        $filters = '';
+
+        if (!\is_bool($options)) {
+            if (isset($options['width']) && is_numeric($options['width']) && $options['width'] > 0) {
+                $imageAttributes .= " width=\"{$options['width']}\"";
+                $w = $options['width'];
+            }
+
+            if (isset($options['height']) && is_numeric($options['height']) && $options['height'] > 0) {
+                $imageAttributes .= " height=\"{$options['height']}\"";
+                $h = $options['height'];
+            }
+
+            if (isset($options['loading']) && ('lazy' === $options['loading'] || 'eager' === $options['loading'])) {
+                $imageAttributes .= " loading=\"{$options['loading']}\"";
+            }
+
+            if (isset($options['class']) && \is_string($options['class']) && '' !== $options['class']) {
+                $imageAttributes .= " class=\"{$options['class']}\"";
+            }
+
+            if (isset($options['filters']) && \is_array($options['filters'])) {
+                if (
+                    isset($options['filters']['blur'])
+                    && $options['filters']['blur'] >= -100
+                    && $options['filters']['blur'] <= 100
+                ) {
+                    $filters .= ":blur({$options['filters']['blur']})";
+                }
+
+                if (
+                    isset($options['filters']['brightness'])
+                    && $options['filters']['brightness'] >= -100
+                    && $options['filters']['brightness'] <= 100
+                ) {
+                    $filters .= ":brightness({$options['filters']['brightness']})";
+                }
+
+                if (
+                    isset($options['filters']['fill'])
+                    && (preg_match('/^[0-9A-Fa-f]{6}$/i', $options['filters']['fill']) || 'transparent' === $options['filters']['fill'])
+                ) {
+                    $filters .= ":fill({$options['filters']['fill']})";
+                }
+
+                if (
+                    isset($options['filters']['format'])
+                    && \in_array($options['filters']['format'], ['webp', 'jpeg', 'png'], true)
+                ) {
+                    $filters .= ':format(' . strtolower($options['filters']['format']) . ')';
+                }
+
+                if (
+                    isset($options['filters']['grayscale'])
+                    && \is_bool($options['filters']['grayscale'])
+                ) {
+                    $filters .= ':grayscale()';
+                }
+
+                if (
+                    isset($options['filters']['quality'])
+                    && $options['filters']['quality'] >= 0
+                    && $options['filters']['quality'] <= 100
+                ) {
+                    $filters .= ":quality({$options['filters']['quality']})";
+                }
+
+                if (
+                    isset($options['filters']['rotate'])
+                    && \in_array($options['filters']['rotate'], [90, 180, 270], true)
+                ) {
+                    $filters .= ":rotate({$options['filters']['rotate']})";
+                }
+
+                if ('' !== $filters) {
+                    $filters = '/filters' . $filters;
+                }
+            }
+        }
+
+        if ('' !== $imageAttributes) {
+            $html = str_replace('<img', '<img ' . trim($imageAttributes), $html);
+        }
+
+        $parameters = $w > 0 || $h > 0 || '' !== $filters ? $w . 'x' . $h . $filters : '';
+
+        $html = preg_replace(
+            '/a.storyblok.com\/f\/(\d+)\/([^.]+)\.(gif|jpg|jpeg|png|tif|tiff|bmp)/',
+            'a.storyblok.com/f/$1/$2.$3/m/' . $parameters,
+            $html
+        );
+
+        if (isset($options['srcset']) || isset($options['sizes'])) {
+            $html = preg_replace_callback(
+                '/<img.*?src=["|\'](.*?)["|\']/',
+                static function ($matches) use ($filters, $options) {
+                    $url = $matches[1];
+                    $srcsetList = [];
+                    $sizesList = [];
+
+                    if (preg_match('/a.storyblok.com\/f\/(\d+)\/([^.]+)\.(gif|jpg|jpeg|png|tif|tiff|bmp)/', $url, $urlMatches)) {
+
+                        if (isset($options['srcset']) && \is_array($options['srcset'])) {
+                            foreach ($options['srcset'] as $value) {
+                                if (is_numeric($value)) {
+                                    $srcsetList[] = '//' . $urlMatches[0] . '/m/' . $value . 'x0' . $filters . ' ' . $value . 'w';
+                                }
+                                if (\is_array($value) && 2 === \count($value)) {
+                                    is_numeric($value[0]) ? $w = $value[0] : $w = 0;
+                                    is_numeric($value[0]) ? $h = $value[1] : $h = 0;
+
+                                    $srcsetList[] = '//' . $urlMatches[0] . '/m/' . $w . 'x' . $h . $filters . ' ' . $w . 'w';
+                                }
+                            }
+                        }
+
+                        if (isset($options['sizes']) && \is_array($options['sizes'])) {
+                            foreach ($options['sizes'] as $size) {
+                                $sizesList[] = $size;
+                            }
+                        }
+
+                        $attributesToRender = '';
+
+                        if (\count($srcsetList) > 0) {
+                            $attributesToRender .= 'srcset="' . implode(', ', $srcsetList) . '" ';
+                        }
+                        if (\count($sizesList) > 0) {
+                            $attributesToRender .= 'sizes="' . implode(', ', $sizesList) . '" ';
+                        }
+
+                        return preg_replace('/<img/', '<img ' . trim($attributesToRender), $matches[0]);
+                    }
+
+                    return $matches[0];
+                },
+                $html
+            );
+        }
+
+        return $html;
     }
 }

--- a/tests/Fixtures/ResolverTestData.php
+++ b/tests/Fixtures/ResolverTestData.php
@@ -1418,4 +1418,21 @@ class ResolverTestData
             ],
         ];
     }
+
+    public static function imageStoredAtStoryblokAssets()
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'attrs' => [
+                        'src' => 'https://a.storyblok.com/f/000000/00a00a00a0/image-name.png',
+                        'name' => 'Text image',
+                        'alt' => 'Alt text',
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/tests/RenderOptmizedImagesTest.php
+++ b/tests/RenderOptmizedImagesTest.php
@@ -1,0 +1,262 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\RichtextRender\Fixtures\ResolverTestData;
+use Storyblok\RichtextRender\Resolver;
+
+final class RenderOptmizedImagesTest extends TestCase
+{
+    protected static $resolver;
+    protected static $data;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$resolver = new Resolver();
+
+        self::$data = ResolverTestData::imageStoredAtStoryblokAssets();
+    }
+
+    public function testCanRenderImageAtStoryblokAssets()
+    {
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data));
+    }
+
+    public function testCanGenerateImgTagWithOptimization()
+    {
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, ['optimizeImages' => true]));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndLoadingLazy()
+    {
+        $options = ['optimizeImages' => ['loading' => 'lazy']];
+
+        $expected = '<img loading="lazy" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndWidth()
+    {
+        $options = ['optimizeImages' => ['width' => 500]];
+
+        $expected = '<img width="500" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/500x0" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndHeight()
+    {
+        $options = ['optimizeImages' => ['height' => 350]];
+
+        $expected = '<img height="350" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x350" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndCustomClasses()
+    {
+        $options = ['optimizeImages' => ['class' => 'w-full my-8']];
+
+        $expected = '<img class="w-full my-8" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['class' => '']];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndBlurFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['blur' => 10]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:blur(10)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndBrightnessFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['brightness' => 15]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:brightness(15)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndFillFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['fill' => 'transparent']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:fill(transparent)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['fill' => 'FFCC99']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:fill(FFCC99)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['fill' => 'INVALID']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndFormatFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['format' => 'png']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:format(png)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['format' => 'webp']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:format(webp)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['format' => 'jpeg']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:format(jpeg)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['format' => 'INVALID']]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndGrayscaleFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['grayscale' => true]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:grayscale()" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndQualityFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['quality' => 90]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:quality(90)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['quality' => -90]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['quality' => 101]]];
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndRotateFilter()
+    {
+        $options = ['optimizeImages' => ['filters' => ['rotate' => 90]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:rotate(90)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['rotate' => 180]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:rotate(180)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['rotate' => 270]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:rotate(270)" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['filters' => ['rotate' => 9999999]]];
+
+        $expected = '<img src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndSrcset()
+    {
+        $options = ['optimizeImages' => ['srcset' => [360, 1024, 1500]]];
+
+        $expected = '<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x0 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x0 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0 1500w" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+        $options = ['optimizeImages' => ['srcset' => [[360, 360], 1024, 1500]]];
+
+        $expected = '<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x360 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x0 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0 1500w" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndSrcsetAndFilterAndLoadingLazy()
+    {
+        $options = ['optimizeImages' => ['loading' => 'lazy', 'filters' => ['grayscale' => true], 'srcset' => [[360, 360], [1024, 768], 1500]]];
+
+        $expected = '<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x360/filters:grayscale() 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x768/filters:grayscale() 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0/filters:grayscale() 1500w" loading="lazy" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:grayscale()" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndSizes()
+    {
+        $options = ['optimizeImages' => ['sizes' => ['(max-width: 767px) 100vw', '(max-width: 1024px) 768px', '1500px']]];
+
+        $expected = '<img sizes="(max-width: 767px) 100vw, (max-width: 1024px) 768px, 1500px" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testCanGenerateImgTagWithOptimizationAndSrcsetAndSizesAndFilterAndLoadingLazy()
+    {
+        $options = ['optimizeImages' => ['loading' => 'lazy', 'filters' => ['grayscale' => true], 'srcset' => [[360, 360], [1024, 768], 1500], 'sizes' => ['(max-width: 767px) 100vw', '(max-width: 1024px) 768px', '1500px']]];
+
+        $expected = '<img srcset="//a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/360x360/filters:grayscale() 360w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1024x768/filters:grayscale() 1024w, //a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/1500x0/filters:grayscale() 1500w" sizes="(max-width: 767px) 100vw, (max-width: 1024px) 768px, 1500px" loading="lazy" src="https://a.storyblok.com/f/000000/00a00a00a0/image-name.png/m/0x0/filters:grayscale()" alt="Alt text" />';
+
+        self::assertSame($expected, self::$resolver->render((object) self::$data, $options));
+    }
+
+    public function testShouldSkipImgTagWithOptimizationAndSrcsetWhenImageIsNotInStoryblokAsset()
+    {
+
+        $data = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'attrs' => [
+                        'src' => 'https://vuejs.org/images/logo.png',
+                        'alt' => 'This is the Vue.js logo',
+                    ],
+                ],
+            ],
+        ];
+
+        $options = ['optimizeImages' => ['srcset' => [360, 1024, 1500]]];
+
+        $expected = '<img src="https://vuejs.org/images/logo.png" alt="This is the Vue.js logo" />';
+
+        self::assertSame($expected, self::$resolver->render((object) $data, $options));
+
+    }
+}


### PR DESCRIPTION
After migrate hundred posts from WP to SB I noticed that a lot of posts has images inside richtext field and with sizes starting from 1MB. Each of these blog posts has ~7mb images in total. This PR adds an option to the render method to automatically return optimized version of images inside the richtext content fields.

With this new feature is possible to resolve some Web Vitals errors like...

- Serve images in next-gen formats
- Defer offscreen images
- Image elements do not have explicit width and height
- Avoid enormous network payloads

...and use filters from [Storyblok Image Service](https://www.storyblok.com/docs/image-service) like blur, brigthness, quality etc...

## Example


```php
$options = [ 
  'optimizeImages' => [
    'class' => 'w-full my-8 border-b border-black',
    'width' => 640, // image width
    'height' => 360, // image height
    'loading' => 'lazy', // 'lazy' | 'eager'
    'filters' => [
      'blur' => 0, // 0 to 100
      'brightness' => 0, // -100 to 100
      'fill' => 'transparent', // Or any hexadecimal value like FFCC99
      'format' => 'webp', // 'webp' | 'jpeg' | 'png'
      'grayscale' => false,
      'quality' => 95, // 0 to 100
      'rotate' => 0 // 0 | 90 | 180 | 270
    ],
    // srcset accepts an array with image widths. 
    // Example: [720, 1024, 1533] 
    // will render srcset="//../m/720x0 720w", "//../m/1024x0 1024w", "//../m/1533x0 1280w"
    // Also accept an array to pass width and height. 
    // Example: [[720,500], 1024, [1500, 1000]] 
    // will render srcset="//../m/720x500 720w", "//../m/1024x0 1024w", "//../m/1280x0 1280w"
    'srcset' => [720, 1024, 1533], 
    'sizes' => [
      '(max-width: 767px) 100vw',
      '(max-width: 1024px) 768px',
      '1500px'
    ]
  ]
]

$resolver->render($data, $options)
```

My storyblok-js-client version: [458 ](https://github.com/storyblok/storyblok-js-client/pull/458) and [491](https://github.com/storyblok/storyblok-js-client/pull/491)